### PR TITLE
Allow spaces in filename

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export class LaTexFormatter {
     }
     private format(filename: string, document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
         return new Promise((resolve, reject) => {
-            cp.exec(this.formatter + ' ' + filename, (err, stdout, stderr) => {
+            cp.exec(this.formatter + ' "' + filename + '"', (err, stdout, stderr) => {
                 if (stdout != '') {
                     var edit = [vscode.TextEdit.replace(fullRange(document), stdout)];
                     return resolve(edit);


### PR DESCRIPTION
I made a small change to surround the path of the file in quotation marks when `latexindent` is called. This should allow for spaces in the path of the file. 

Tested on macOS 10.12.4, Code 1.12.1, TeXLive 2016, latexindent 3.0.